### PR TITLE
allow the user to provide custom db setup config

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,7 @@
+cradle:
+  stack:
+    components:
+    - path: "./src"
+      component: "hspec-pg-transact:lib"
+    - path: "./test"
+      component: "hspec-pg-transact:test:test"

--- a/hspec-pg-transact.cabal
+++ b/hspec-pg-transact.cabal
@@ -45,8 +45,26 @@ library
                , bytestring
                , text
                , resource-pool
-  default-language:    Haskell2010
+  default-language: Haskell2010
   ghc-options: -Wall -Wno-unused-do-bind
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Hspec.DBSpec
+  hs-source-dirs:
+      test
+  build-depends:
+      base >= 4.7 && < 5
+    , hspec-pg-transact
+    , pg-transact
+    , postgresql-simple
+    , hspec
+    , hspec-core
+    , tmp-postgres
+  default-language: Haskell2010
+  ghc-options: -Wall -Wno-unused-do-bind -threaded -rtsopts -with-rtsopts=-N
 
 source-repository head
   type:     git

--- a/test/Hspec/DBSpec.hs
+++ b/test/Hspec/DBSpec.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE QuasiQuotes      #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-deferred-type-errors #-}
+
+module Hspec.DBSpec where
+
+import           Control.Monad.IO.Class           (MonadIO (liftIO))
+import           Data.Functor                     (void)
+import           Data.Monoid                      (Last (Last))
+import           Database.PostgreSQL.Simple       (Only (..))
+import           Database.PostgreSQL.Simple.SqlQQ (sql)
+import           Database.PostgreSQL.Transact     (DBT, execute, execute_,
+                                                   query_, runDBTSerializable)
+import           Database.Postgres.Temp           (Config (port, postgresConfig),
+                                                   ProcessConfig (stdIn, stdOut),
+                                                   defaultConfig)
+import           System.IO                        (Handle)
+import           Test.Hspec                       (SpecWith, shouldBe)
+import           Test.Hspec.Core.Spec             (Spec)
+import           Test.Hspec.DB                    (TestDB, describeDB,
+                                                   describeDBWithConfig, itDB)
+
+defaultSpec :: Spec
+defaultSpec =
+  describeDB (runDBTSerializable migrate) "with default config" test
+
+customSpec :: Handle -> Handle -> Spec
+customSpec i o =
+  describeDBWithConfig
+    ( defaultConfig
+        { postgresConfig =
+            (postgresConfig defaultConfig)
+              { stdIn = Last $ Just i,
+                stdOut = Last $ Just o
+              }
+        , port = Last $ Just $ Just 8999
+        }
+    )
+    (runDBTSerializable migrate)
+    "with custom config"
+    test
+
+migrate :: DBT IO ()
+migrate = void $ execute_ [sql| CREATE TABLE things (n VARCHAR NOT NULL) |]
+
+test :: SpecWith TestDB
+test =
+  itDB "basic insert/select" $ do
+    execute [sql| INSERT INTO things (n) VALUES (?) |] (Only name)
+    name' <- query_ [sql| SELECT n FROM things |]
+    liftIO $ name' `shouldBe` [Only name]
+  where
+    name = "dupont"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,16 @@
+module Main where
+
+import qualified Hspec.DBSpec
+import           System.IO
+import           Test.Hspec   (Spec, describe, hspec)
+
+main :: IO ()
+main = do
+  withFile "/tmp/pgto.log" AppendMode $
+    hspec . spec stdin
+
+spec :: Handle -> Handle -> Spec
+spec i o = do
+  describe "pg-transact-hspec" $ do
+    Hspec.DBSpec.defaultSpec
+    Hspec.DBSpec.customSpec i o


### PR DESCRIPTION
Following #2 

@tchoutri  I opened a new PR because my old account is not valid anymore. Feel free to close the previous one :).

Since the user is now able to provide a custom configuration to the library, we no longer need to handle it manually (like I did 2 years ago).

The main changes:
- added wrappers that would let the user pipe it's own configuration `setupDBWithConfig/describeDBWithConfig`
- added some tests and created the according `hie.yaml` for hls.
- removed the `RecordsWildCards` extension to keep the code as simple as possible.
- added an `error` call if we encounter any failure while setting up the database (I know it's ugly, but I don't see any benefit in being able to continue testing in such case).

Let me know if you want me to change anything.